### PR TITLE
feat(argocd): support generic ArgoCD API kinds

### DIFF
--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -90,6 +90,26 @@ class ArgocdClient:
                 return []
             raise e
 
+    async def get_generic_resources(self, kind: str) -> list[dict[str, Any]]:
+        """Fetch resources for a generic ArgoCD API kind not explicitly defined in ObjectKind.
+
+        The kind should match the ArgoCD API path segment (e.g., 'repositories', 'certificates', 'gpgkeys').
+        The response is expected to have an 'items' key containing a list of resources.
+        """
+        url = f"{self.api_url}/{kind}"
+        try:
+            response_data = await self._send_api_request(url=url)
+            if not response_data:
+                return []
+            if "items" in response_data:
+                return response_data["items"] or []
+            return [response_data]
+        except Exception as e:
+            logger.error(f"Failed to fetch generic resources of kind {kind}: {e}")
+            if self.ignore_server_error:
+                return []
+            raise e
+
     async def get_application_by_name(self, name: str) -> dict[str, Any]:
         url = f"{self.api_url}/{ObjectKind.APPLICATION}s/{name}"
         application = await self._send_api_request(url=url)

--- a/integrations/argocd/main.py
+++ b/integrations/argocd/main.py
@@ -20,9 +20,17 @@ async def on_resources_resync(kind: str) -> RAW_RESULT:
     if kind in iter(ResourceKindsWithSpecialHandling):
         logger.info(f"Kind {kind} has a special handling. Skipping...")
         return []
-    else:
-        argocd_client = init_client()
-        return await argocd_client.get_resources(resource_kind=ObjectKind(kind))
+
+    argocd_client = init_client()
+
+    try:
+        object_kind = ObjectKind(kind)
+        return await argocd_client.get_resources(resource_kind=object_kind)
+    except ValueError:
+        logger.info(
+            f"Kind '{kind}' is not a predefined ArgoCD kind, fetching as generic resource from /api/v1/{kind}"
+        )
+        return await argocd_client.get_generic_resources(kind=kind)
 
 
 @ocean.on_resync(kind=ResourceKindsWithSpecialHandling.DEPLOYMENT_HISTORY)

--- a/integrations/argocd/tests/test_client.py
+++ b/integrations/argocd/tests/test_client.py
@@ -269,3 +269,70 @@ async def test_get_managed_resources(
                 mock_request.assert_called_with(
                     url=f"{mock_argocd_client.api_url}/{ObjectKind.APPLICATION}s/{application_name}/managed-resources"
                 )
+
+
+@pytest.mark.asyncio
+async def test_get_generic_resources_with_items(
+    mock_argocd_client: ArgocdClient,
+) -> None:
+    response_data = {
+        "items": [
+            {"type": "git", "repo": "https://github.com/example/repo.git"},
+            {"type": "helm", "repo": "https://charts.example.com"},
+        ]
+    }
+    with patch.object(
+        mock_argocd_client, "_send_api_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = response_data
+        resources = await mock_argocd_client.get_generic_resources(
+            kind="repositories"
+        )
+        assert resources == response_data["items"]
+        mock_request.assert_called_with(
+            url=f"{mock_argocd_client.api_url}/repositories"
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_generic_resources_without_items(
+    mock_argocd_client: ArgocdClient,
+) -> None:
+    response_data = {"version": "v2.5.0", "buildDate": "2023-01-01"}
+    with patch.object(
+        mock_argocd_client, "_send_api_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = response_data
+        resources = await mock_argocd_client.get_generic_resources(kind="settings")
+        assert resources == [response_data]
+        mock_request.assert_called_with(
+            url=f"{mock_argocd_client.api_url}/settings"
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_generic_resources_empty_items(
+    mock_argocd_client: ArgocdClient,
+) -> None:
+    with patch.object(
+        mock_argocd_client, "_send_api_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = {"items": []}
+        resources = await mock_argocd_client.get_generic_resources(
+            kind="repositories"
+        )
+        assert resources == []
+
+
+@pytest.mark.asyncio
+async def test_get_generic_resources_error_returns_empty(
+    mock_argocd_client: ArgocdClient,
+) -> None:
+    with patch.object(
+        mock_argocd_client, "_send_api_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.side_effect = Exception("API error")
+        resources = await mock_argocd_client.get_generic_resources(
+            kind="repositories"
+        )
+        assert resources == []


### PR DESCRIPTION
## Summary

- Adds support for ingesting any ArgoCD API resource (e.g., `repositories`, `certificates`, `gpgkeys`, `settings`) without requiring code changes to the integration
- When a kind doesn't match a predefined `ObjectKind`, the generic resync handler falls back to calling `/api/v1/{kind}` directly
- Handles both list responses (with `items` key) and singleton responses (like `/api/v1/settings`)

## How it works

Users can now add any ArgoCD API resource to their `port-app-config.yaml` by using the API path segment as the kind name:

```yaml
resources:
  - kind: repositories
    selector:
      query: "true"
    port:
      entity:
        mappings:
          identifier: .repo
          title: .repo
          blueprint: '"argocdRepository"'
          properties:
            type: .type
            repo: .repo
```

## Test plan

- [x] Added unit tests for `get_generic_resources` with items response
- [x] Added unit tests for singleton response (no `items` key)
- [x] Added unit tests for empty items and error cases
- [x] Verified logic handles edge cases (empty dict, None items, missing items key)
- [ ] Existing predefined kinds (`cluster`, `project`, `application`) continue to work unchanged

https://claude.ai/code/session_014u6e1SKVE5gQ1CeXfCdbFm